### PR TITLE
elivepatch-server: add a cmdline option to specify the number of make jobs

### DIFF
--- a/elivepatch_server/elivepatch-server
+++ b/elivepatch_server/elivepatch-server
@@ -7,7 +7,17 @@
 
 from flask import Flask
 from flask_restful import Api
+import multiprocessing
+import argparse
 from elivepatch_server.resources import AgentInfo, dispatcher
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-j', '--jobs', type=int,
+                        default=multiprocessing.cpu_count())
+
+    return parser.parse_args()
 
 def create_app():
     """
@@ -17,6 +27,8 @@ def create_app():
 
     app = Flask(__name__, static_url_path="")
     api = Api(app)
+
+    cmdline_args = parse_args()
 
     api.add_resource(AgentInfo.AgentAPI, '/elivepatch/api/',
                      endpoint='root')
@@ -32,7 +44,8 @@ def create_app():
 
     # where to receive the config file
     api.add_resource(dispatcher.GetFiles, '/elivepatch/api/v1.0/get_files',
-                     endpoint='config')
+                     endpoint='config',
+                     resource_class_kwargs={'cmdline_args': cmdline_args})
     return app
 
 if __name__ == '__main__':

--- a/elivepatch_server/resources/dispatcher.py
+++ b/elivepatch_server/resources/dispatcher.py
@@ -84,7 +84,7 @@ class SendLivePatch(Resource):
 
 class GetFiles(Resource):
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.reqparse = reqparse.RequestParser()
         self.reqparse.add_argument('KernelVersion', type=str, required=False,
                                    help='No task title provided',
@@ -92,6 +92,7 @@ class GetFiles(Resource):
         self.reqparse.add_argument('UUID', type=str, required=False,
                                    help='No task title provided',
                                    location='headers')
+        self.cmdline_args = kwargs['cmdline_args']
         super(GetFiles, self).__init__()
         pass
 
@@ -157,7 +158,7 @@ class GetFiles(Resource):
         kernel_sources_status = lpatch.get_kernel_sources(args['KernelVersion'])
         if not kernel_sources_status:
             return make_response(jsonify({'message': 'gentoo-sources not available'}), 403)
-        lpatch.build_livepatch('vmlinux')
+        lpatch.build_livepatch('vmlinux', jobs=self.cmdline_args.jobs)
 
         pack = {
            'id': packs['id'] + 1,

--- a/elivepatch_server/resources/livepatch.py
+++ b/elivepatch_server/resources/livepatch.py
@@ -19,7 +19,7 @@ class PaTch(object):
 
         self.__kernel_source_dir__ = os.path.join(self.base_dir, 'usr/src/linux/')
 
-    def build_livepatch(self, vmlinux, debug=True):
+    def build_livepatch(self, vmlinux, jobs, debug=True):
         """
         Function for building the livepatch
 
@@ -32,7 +32,7 @@ class PaTch(object):
 
         os.makedirs(kpatch_cachedir)
         if not os.path.isfile(vmlinux_source):
-            self.build_kernel()
+            self.build_kernel(jobs)
 
         bashCommand = ['kpatch-build']
         bashCommand.extend(['-s', self.__kernel_source_dir__])
@@ -85,7 +85,7 @@ class PaTch(object):
             kernel_sources_status = None
         return kernel_sources_status
 
-    def build_kernel(self):
+    def build_kernel(self, jobs):
         kernel_config_path = os.path.join(self.__kernel_source_dir__, '.config')
 
         if 'CONFIG_DEBUG_INFO=y' in open(self.base_config_path).read():
@@ -104,15 +104,7 @@ class PaTch(object):
         # copy the olddefconfig generated config file back,
         # so that we don't trigger a config restart when kpatch-build runs
         shutil.copyfile(kernel_config_path, self.base_config_path)
-        # Getting enviroment variable
-        try:
-            jobs = os.environ['JOBS']
-        except:
-            jobs = None
-        if jobs:
-            _command(['make', jobs], self.__kernel_source_dir__)
-        else:
-            _command(['make'], self.__kernel_source_dir__)
+        _command(['make', '-j{}'.format(jobs)], self.__kernel_source_dir__)
         _command(['make', 'modules'], self.__kernel_source_dir__)
 
 


### PR DESCRIPTION
Provide the command line option ('-j', '--jobs') to specify the number
of make jobs when compiling the kernel. This commit does not extend
the support to kpatch-build yet.

Closes: https://github.com/aliceinwire/elivepatch-server/issues/2