### PR TITLE
Kpatch jobs

### DIFF
--- a/elivepatch_server/resources/livepatch.py
+++ b/elivepatch_server/resources/livepatch.py
@@ -105,7 +105,7 @@ class PaTch(object):
         # copy the olddefconfig generated config file back,
         # so that we don't trigger a config restart when kpatch-build runs
         shutil.copyfile(kernel_config_path, self.base_config_path)
-        _command(['make', '-j{}'.format(jobs)], self.__kernel_source_dir__)
+        _command(['make', '-j', str(jobs)], self.__kernel_source_dir__)
         _command(['make', 'modules'], self.__kernel_source_dir__)
 
 

--- a/elivepatch_server/resources/livepatch.py
+++ b/elivepatch_server/resources/livepatch.py
@@ -34,13 +34,13 @@ class PaTch(object):
         if not os.path.isfile(vmlinux_source):
             self.build_kernel(jobs)
 
-        bashCommand = ['kpatch-build']
-        bashCommand.extend(['-s', self.__kernel_source_dir__])
-        bashCommand.extend(['-v', vmlinux_source])
-        bashCommand.extend(['-j', str(jobs)])
-        bashCommand.extend(['-c', 'config'])
-        bashCommand.extend(['main.patch'])
-        bashCommand.extend(['--skip-gcc-check'])
+        bashCommand = ['kpatch-build',
+                       '-s', self.__kernel_source_dir__,
+                       '-v', vmlinux_source,
+                       '-j', str(jobs),
+                       '-c', 'config',
+                       '--skip-gcc-check',
+                       'main.patch']
         if debug:
             bashCommand.extend(['--skip-cleanup'])
             bashCommand.extend(['--debug'])

--- a/elivepatch_server/resources/livepatch.py
+++ b/elivepatch_server/resources/livepatch.py
@@ -37,6 +37,7 @@ class PaTch(object):
         bashCommand = ['kpatch-build']
         bashCommand.extend(['-s', self.__kernel_source_dir__])
         bashCommand.extend(['-v', vmlinux_source])
+        bashCommand.extend(['-j', str(jobs)])
         bashCommand.extend(['-c', 'config'])
         bashCommand.extend(['main.patch'])
         bashCommand.extend(['--skip-gcc-check'])


### PR DESCRIPTION
This PR extends `--jobs` support to kpatch since the support is merged upstream. It also cleans up the code a bit.