### PR TITLE
[RFC] Tmp file clean

### DIFF
--- a/elivepatch_server/resources/dispatcher.py
+++ b/elivepatch_server/resources/dispatcher.py
@@ -166,3 +166,6 @@ class GetFiles(Resource):
             'UUID' : args['UUID']
         }
         return {'get_config': marshal(pack, pack_fields)}, 201
+
+    def __del__(self):
+        print('deleting function')


### PR DESCRIPTION
Draft of cleaning temporary files for elivepatch-server.
In this patch, I'm using _ _ del _ _ for cleaning temporary files when the thread exit, I'm removing the folder /tmp/elivepatch + uuid for removing the kernel source code and everything not needed anymore.
But I'm saving the live patch and the build.log file under /tmp/livepatch/ + uuid for being possible to recover the live patch in the second time and keeping build.log for see what is gone wrong if something went wrong.
